### PR TITLE
Implement greedy iterator

### DIFF
--- a/src/Persistence/FifoIterator.php
+++ b/src/Persistence/FifoIterator.php
@@ -20,23 +20,97 @@
  */
 namespace oat\Taskqueue\Persistence;
 
-use oat\oatbox\service\ConfigurableService;
 use oat\Taskqueue\JsonTask;
 use oat\oatbox\task\Task;
+use Iterator;
 
-class FifoIterator extends \common_persistence_sql_QueryIterator
+class FifoIterator implements Iterator
 {
+    /**
+     * @var \common_persistence_SqlPersistence
+     */
+    private $persistence;
+
+    /**
+     * Query to iterator over
+     *
+     * @var string
+     */
+    private $query;
+
+    /**
+     * Query parameters
+     *
+     * @var string
+     */
+    private $params;
+
+    /**
+     * @var int
+     */
+    private $key = 0;
+
+    /**
+     * @var array
+     */
+    private $cache;
+
     public function __construct($persistence)
     {
+        $this->persistence = $persistence;
         $query = 'select * from '.RdsQueue::QUEUE_TABLE_NAME.' WHERE '.RdsQueue::QUEUE_STATUS.' = ? ORDER BY '.RdsQueue::QUEUE_ADDED;
-        parent::__construct($persistence, $query, array(Task::STATUS_CREATED));
+        $this->query = $query;
+        $this->params = array(Task::STATUS_CREATED);
+        $this->load();
+        $this->rewind();
     }
-    
+
+    /**
+     * @return int
+     */
+    public function key()
+    {
+        return $this->key;
+    }
+
+    public function rewind()
+    {
+        $this->key = 0;
+    }
+
+    /**
+     * @return JsonTask
+     */
     public function current()
     {
-        $taskData = parent::current();
+        $taskData = $this->cache[$this->key];
         $task = JsonTask::restore($taskData[RdsQueue::QUEUE_TASK]);
         $task->setId($taskData[RdsQueue::QUEUE_ID]);
         return $task;
+    }
+
+    public function next()
+    {
+        ++$this->key;
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid()
+    {
+        return isset($this->cache[$this->key]);
+    }
+
+    /**
+     * Loads all the results in cache
+     */
+    protected function load()
+    {
+        $result = $this->persistence->query($this->query, $this->params);
+        $this->cache = [];
+        while ($statement = $result->fetch()) {
+            $this->cache[] = $statement;
+        }
     }
 }

--- a/test/Persistence/RdsQueueTest.php
+++ b/test/Persistence/RdsQueueTest.php
@@ -86,7 +86,7 @@ class RdsQueueTest extends PHPUnit_Framework_TestCase
     {
         $queue = $this->getInstance();
         $iterator = $queue->getIterator();
-        $this->assertTrue($iterator instanceof \common_persistence_sql_QueryIterator);
+        $this->assertTrue($iterator instanceof \Iterator);
     }
 
     protected function deleteTask($id)


### PR DESCRIPTION
Iterator for task queue should load all the task at once because during execution of some tasks they can by put themselves in the queue again (because of fail or just recurring tasks (see https://github.com/oat-sa/extension-tao-proctoring/pull/184/files#diff-709d9f446c9ff55afbdde6aad09c9e21R137)). Previous implementation of iterator fetch those new tasks from db during `next()` call.
